### PR TITLE
Defer creation of HTTP connections until actually needed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ install_requires =
     requests >= 2.0.0
     requests-oauthlib
     pyyaml >= 6.0
+    cached_property;python_version<"3.8"
 python_requires = >=3.6
 
 [options.extras_require]

--- a/supersetapiclient/base.py
+++ b/supersetapiclient/base.py
@@ -1,6 +1,11 @@
 """Base classes."""
 import logging
 import dataclasses
+try:
+    from functools import cached_property
+except ImportError:
+    # Python<3.8
+    from cached_property import cached_property
 import json
 from typing import List, Union
 from pathlib import Path
@@ -152,9 +157,11 @@ class ObjectFactories:
         """
         self.client = client
 
+    @cached_property
+    def _infos(self):
         # Get infos
-        response = client.get(
-            client.join_urls(
+        response = self.client.get(
+            self.client.join_urls(
                 self.base_url,
                 "_info",
             ),
@@ -166,34 +173,21 @@ class ObjectFactories:
             logger.error(f"Unable to build object factory for {self.endpoint}")
             response.raise_for_status()
 
-        infos = response.json()
-        self.edit_columns = [
+        return response.json()
+
+    @property
+    def add_columns(self):
+        return [
             e.get("name")
-            for e in infos.get("edit_columns", [])
+            for e in self._infos.get("add_columns", [])
         ]
-        #
-        # Need to find a solution
-        #
-        # Due to the design of the superset API,
-        # get /chart/_info only returns 'slice_name'
-        # for chart adds to work,
-        # we require the additional attributes:
-        #   'datasource_id',
-        #   'datasource_type'
-        if self.__class__.__name__ == 'Charts':
-            self.add_columns = [
-                'datasource_id',
-                'datasource_type',
-                'slice_name',
-                'params',
-                'viz_type',
-                'description'
-            ]
-        else:
-            self.add_columns = [
-                e.get("name")
-                for e in infos.get("add_columns", [])
-            ]
+
+    @property
+    def edit_columns(self):
+        return [
+            e.get("name")
+            for e in self._infos.get("edit_columns", [])
+        ]
 
     @property
     def base_url(self):

--- a/supersetapiclient/charts.py
+++ b/supersetapiclient/charts.py
@@ -25,3 +25,20 @@ class Chart(Object):
 class Charts(ObjectFactories):
     endpoint = "/chart/"
     base_object = Chart
+
+    @property
+    def add_columns(self):
+        # Due to the design of the superset API,
+        # get /chart/_info only returns 'slice_name'
+        # For chart adds to work,
+        # we require the additional attributes:
+        #   'datasource_id',
+        #   'datasource_type'
+        return [
+            'datasource_id',
+            'datasource_type',
+            'slice_name',
+            'params',
+            'viz_type',
+            'description'
+        ]

--- a/supersetapiclient/client.py
+++ b/supersetapiclient/client.py
@@ -1,9 +1,13 @@
 """A Superset REST Api Client."""
 import getpass
 import logging
-from functools import partial
-from typing import Dict
+try:
+    from functools import cached_property
+except ImportError:
+    # Python<3.8
+    from cached_property import cached_property
 
+import requests.adapters
 import requests.exceptions
 import requests_oauthlib
 
@@ -24,6 +28,7 @@ class SupersetClient:
     datasets_cls = Datasets
     databases_cls = Databases
     saved_queries_cls = SavedQueries
+    http_adapter_cls = None
 
     def __init__(
         self,
@@ -38,48 +43,8 @@ class SupersetClient:
         self.username = username
         self._password = password
         self.provider = provider
-        self.verify = verify
-
-        self._token = self.authenticate()
-        self.session = requests_oauthlib.OAuth2Session(token=self._token)
-        self.session.hooks['response'] = [self.token_refresher]
-
-        # Get CSRF Token
-        self._csrf_token = None
-        csrf_response = self.session.get(
-            self.join_urls(self.base_url, "/security/csrf_token/"),
-            headers=self._headers,
-            verify=self.verify
-        )
-        csrf_response.raise_for_status()  # Check CSRF Token went well
-        self._csrf_token = csrf_response.json().get("result")
-
-        # Update headers
-        self.session.headers.update(
-            self._headers
-        )
-
-        # Bind method
-        self.get = partial(
-            self.session.get,
-            headers=self._headers,
-            verify=self.verify
-        )
-        self.post = partial(
-            self.session.post,
-            headers=self._headers,
-            verify=self.verify
-        )
-        self.put = partial(
-            self.session.put,
-            headers=self._headers,
-            verify=self.verify
-        )
-        self.delete = partial(
-            self.session.delete,
-            headers=self._headers,
-            verify=self.verify
-        )
+        if not verify:
+            self.http_adapter_cls = NoVerifyHTTPAdapter
 
         # Related Objects
         self.dashboards = self.dashboards_cls(self)
@@ -87,6 +52,41 @@ class SupersetClient:
         self.datasets = self.datasets_cls(self)
         self.databases = self.databases_cls(self)
         self.saved_queries = self.saved_queries_cls(self)
+
+    @cached_property
+    def _token(self):
+        return self.authenticate()
+
+    @cached_property
+    def session(self):
+        session = requests_oauthlib.OAuth2Session(token=self._token)
+        session.hooks['response'] = [self.token_refresher]
+        if self.http_adapter_cls:
+            session.mount(self.host, adapter=self.http_adapter_cls())
+
+        # Update headers
+        session.headers.update({
+            "X-CSRFToken": f"{self.csrf_token(session)}",
+            "Referer": f"{self.base_url}"
+        })
+        return session
+
+    # Method shortcuts
+    @property
+    def get(self):
+        return self.session.get
+
+    @property
+    def post(self):
+        return self.session.post
+
+    @property
+    def put(self):
+        return self.session.put
+
+    @property
+    def delete(self):
+        return self.session.delete
 
     @staticmethod
     def join_urls(*args) -> str:
@@ -119,7 +119,7 @@ class SupersetClient:
             "password": self._password,
             "provider": self.provider,
             "refresh": "true"
-        }, verify=self.verify)
+        })
         response.raise_for_status()
         return response.json()
 
@@ -205,13 +205,18 @@ class SupersetClient:
     def _sql_endpoint(self) -> str:
         return self.join_urls(self.host, "superset/sql_json/")
 
-    @property
-    def csrf_token(self) -> str:
-        return self._csrf_token
+    def csrf_token(self, session) -> str:
+        # Get CSRF Token
+        csrf_response = session.get(
+            self.join_urls(self.base_url, "/security/csrf_token/"),
+            headers={"Referer": f"{self.base_url}"},
+        )
+        csrf_response.raise_for_status()  # Check CSRF Token went well
+        return csrf_response.json().get("result")
 
-    @property
-    def _headers(self) -> Dict[str, str]:
-        return {
-            "X-CSRFToken": f"{self.csrf_token}",
-            "Referer": f"{self.base_url}"
-        }
+
+class NoVerifyHTTPAdapter(requests.adapters.HTTPAdapter):
+    """An HTTP adapter that ignores TLS validation errors"""
+
+    def cert_verify(self, conn, url, verify, cert):
+        super().cert_verify(conn=conn, url=url, verify=False, cert=cert)


### PR DESCRIPTION
Defer the fetching of CSRF and auth tokens and information for list endpoints until this information is actually necessary for the client. This allows calling `SupersetClient(host='https://example.com')` without creating any HTTP requests.

Use an adapter to disable TLS verification, as recommended upstream.

Don't update session headers that have already been updated. This removes the need for partial methods.

Make CSRF token fetching customizable.