### PR TITLE
Support assets endpoint

### DIFF
--- a/supersetapiclient/assets.py
+++ b/supersetapiclient/assets.py
@@ -1,0 +1,64 @@
+"""Assets."""
+import json
+from pathlib import Path
+from typing import Union
+
+from supersetapiclient.base import raise_for_status
+
+
+class Assets:
+    endpoint = "assets/"
+
+    def __init__(self, client):
+        self.client = client
+
+    @property
+    def base_url(self):
+        """Base url for these objects."""
+        return self.client.join_urls(self.client.base_url, self.endpoint)
+
+    @property
+    def import_url(self):
+        return self.client.join_urls(self.base_url, "import/")
+
+    @property
+    def export_url(self):
+        return self.client.join_urls(self.base_url, "export/")
+
+    def export(self, path: Union[Path, str]) -> None:
+        """Export object into an importable file"""
+        response = self.client.get(self.export_url)
+        raise_for_status(response)
+
+        content_type = response.headers["content-type"].strip()
+        if content_type.startswith("application/zip"):
+            data = response.content
+            with open(path, "wb") as f:
+                f.write(data)
+            return
+        raise ValueError(f"Unknown content type {content_type}")
+
+    def import_file(self, file_path, passwords=None) -> bool:
+        """Import a file on remote.
+
+        :param file_path: Path to a JSON or ZIP file containing the import data
+        :param passwords: JSON map of passwords for each featured database in
+        the file. If the ZIP includes a database config in the path
+        databases/MyDatabase.yaml, the password should be provided in the
+        following format: {"MyDatabase": "my_password"}
+        """
+        file_path = Path(file_path)
+        if not file_path.exists():
+            return False
+        file_ext = file_path.suffix.replace(".", "")
+        passwords = {f"databases/{db}.yaml": pwd for db, pwd in (passwords or {}).items()}
+
+        files = {
+            "bundle": (file_path.name, open(file_path.name, 'rb'), f"application/{file_ext}"),
+            "passwords": json.dumps(passwords),
+        }
+        response = self.client.post(self.import_url, files=files)
+        raise_for_status(response)
+
+        # If import is successful, the following is returned: {'message': 'OK'}
+        return response.json().get("message") == "OK"

--- a/supersetapiclient/assets.py
+++ b/supersetapiclient/assets.py
@@ -54,7 +54,7 @@ class Assets:
         passwords = {f"databases/{db}.yaml": pwd for db, pwd in (passwords or {}).items()}
 
         files = {
-            "bundle": (file_path.name, open(file_path.name, 'rb'), f"application/{file_ext}"),
+            "bundle": (file_path.name, open(file_path.name, "rb"), f"application/{file_ext}"),
             "passwords": json.dumps(passwords),
         }
         response = self.client.post(self.import_url, files=files)

--- a/supersetapiclient/client.py
+++ b/supersetapiclient/client.py
@@ -12,6 +12,7 @@ import requests.adapters
 import requests.exceptions
 import requests_oauthlib
 
+from supersetapiclient.assets import Assets
 from supersetapiclient.base import raise_for_status
 from supersetapiclient.charts import Charts
 from supersetapiclient.dashboards import Dashboards
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 class SupersetClient:
     """A Superset Client."""
 
+    assets_cls = Assets
     dashboards_cls = Dashboards
     charts_cls = Charts
     datasets_cls = Datasets
@@ -50,6 +52,7 @@ class SupersetClient:
             self.http_adapter_cls = NoVerifyHTTPAdapter
 
         # Related Objects
+        self.assets = self.assets_cls(self)
         self.dashboards = self.dashboards_cls(self)
         self.charts = self.charts_cls(self)
         self.datasets = self.datasets_cls(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,17 +25,14 @@ class CustomClient(SupersetClient):
 
 @pytest.fixture
 def permanent_requests(requests_mock):  # noqa
-
     # List domain in folder
     for domain in API_MOCKS.iterdir():
         domain_name = domain.name
 
         if domain.is_dir():
-
             # List file in dir
             for endpoint in domain.iterdir():
                 if endpoint.is_file():
-
                     endpoint_name, action = endpoint.name.split(".")
 
                     # Register mock on action within domain and endpoint
@@ -46,7 +43,6 @@ def permanent_requests(requests_mock):  # noqa
 
 @pytest.fixture
 def client(permanent_requests):
-
     client = SupersetClient(SUPERSET_BASE_URI, "test", "test")
     yield client
 


### PR DESCRIPTION
This PR adds the `assets/` endpoint allowing to import/export all Superset assets with single client commands.

Export:

```py
client.assets.export("export.zip")
```

Import:

```py
client.assets.import("export.zip", {"MyDatabase": "my_password"})
```